### PR TITLE
Subir el archivo .evn

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SPOONACULAR_API_KEY="TU_API_KEY"; // ← Reemplaza esto con tu clave real


### PR DESCRIPTION
Agrego archivo .env de ejemplo sin clave API, útil para referencia de configuración local.
El archivo .env se usa para guardar variables sensibles o de configuración, como claves de API, contraseñas, rutas, etc.